### PR TITLE
Change imports in ort_inference_session.rs & rewrite main.rs.

### DIFF
--- a/src/dnn/ort_inference_session.rs
+++ b/src/dnn/ort_inference_session.rs
@@ -1,5 +1,7 @@
 use ndarray::{ArrayBase, Dim, OwnedRepr};
-use ort::{Session, SessionBuilder, SessionOutputs, Tensor, Value, SessionInputs, SessionInputValue};
+use ort::session::{Session, SessionInputs, SessionInputValue, SessionOutputs};
+use ort::session::builder::SessionBuilder;
+use ort::value::{Tensor, Value};
 use std::path::Path;
 use std::time::Instant;
 use std::borrow::Cow;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,44 +4,39 @@ use yolo_rust_ort::yolo::yolo_session::YoloSession;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let image_path = if args.len() > 1 {
-        &args[1]
-    } else {
-        println!("Warning: No image path provided. Using default image 'sample/horses0.jpg'.");
-        "sample/horses0.jpg"
+    let image_path = match args.get(1) {
+        Some(arg) => arg,
+        None => {
+            println!("Warning: No image path provided. Using default image 'sample/horses0.jpg.");
+            "sample/horses0.jpg"
+        }
+    };
+    let model_path = match args.get(2) {
+        Some(arg) => Path::new(arg),
+        None => {
+            println!("Warning: No model path provided. Using default model 'onnx/yolov10n.onnx'.");
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("onnx").join("yolov10n.onnx")
+        }
+    };
+    let model_name = match args.get(3) {
+        Some(arg) => arg.clone(),
+        None => {
+            println!("Warning: No model name provided. Using default model name 'yolov10'.");
+            "yolov10".to_string()
+        }
+    };
+    let use_nms = match args.get(4) {
+        Some(arg) => arg.parse::<bool>()
+            .map_err(|e| println!("Error parsing nms argument: {}. Defaulting to false.", e))
+            .unwrap_or(false),
+        None => {
+            println!("Warning: No NMS flag provided. Using default NMS flag 'false'.");
+            false
+        }
     };
 
-    let default_model_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("onnx")
-        .join("yolov10n.onnx");
-
-    let model_path = if args.len() > 2 {
-        Path::new(&args[2])
-    } else {
-        println!("Warning: No model path provided. Using default model 'onnx/yolov10n.onnx'.");
-        &default_model_path
-    };
-
-    let model_name = if args.len() > 3 {
-        args[3].clone()
-    } else {
-        println!("Warning: No model name provided. Using default model name 'yolov10'.");
-        "yolov10".to_string()
-    };
-
-    let use_nms = if args.len() > 4 {
-        args[4].parse::<bool>().unwrap_or(false)
-    } else {
-        println!("Warning: No NMS flag provided. Using default NMS flag 'false'.");
-        false
-    };
-
-    let yolo_model = YoloSession::new(
-        &model_path,
-        (640, 640),
-        use_nms,
-        model_name,
-    ).expect("Failed to create YOLO model");
+    let yolo_model = YoloSession::new(&model_path, (640, 640), use_nms, model_name)
+        .expect("Failed to create YOLO model");
 
     yolo_model.process_image(image_path);
 }


### PR DESCRIPTION
When running 'cargo run' using the example, the compiler complained that it could not resolve the imports directly from ort. By following the compiler's hints I was able to get it to run by importing from specific modules. If this is a my-machine-specific issue then please ignore the changes to ort_inference_session.rs.  

I also changed main.rs to use more idiomatic Rust, and added a short print statement for when `arg.parse::<bool>()` encounters an error.  

Really cool repo by the way. I am going to try to use this in my research software (also GPL licensed.)